### PR TITLE
Bugfix/nested nulls

### DIFF
--- a/src/Parquet.Test/Rows/DataColumnsToRowsConverterTest.cs
+++ b/src/Parquet.Test/Rows/DataColumnsToRowsConverterTest.cs
@@ -1,0 +1,111 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Parquet.Data;
+using Parquet.Rows;
+using Parquet.Schema;
+using Xunit;
+
+namespace Parquet.Test.Rows {
+
+    public class DataColumnsToRowsConverterTest : TestBase {
+
+        [Fact]
+        public void Convert_should_process_deeply_nested_structs_with_no_null_values() {
+            // arrange
+            // create a complex nested schema
+            /*
+             * { id, obj: { metadata, arrray: [ {prop1, prop2}, {prop1, prop2} ] } }
+             */
+            var prop1 = new DataField("prop1", typeof(string), isNullable: true);
+            var prop2 = new DataField("prop2", typeof(DateTime?), isNullable: true);
+            var array = new ListField("array", new StructField("item", new Field[] { prop1, prop2 }));
+            var metadata = new DataField("metadata", typeof(int), isNullable: false);
+            var obj = new StructField("obj", new Field[] { metadata, array });
+            var idField = new DataField("id", typeof(string), isNullable: true);
+
+            var schema = new ParquetSchema(new Field[] { idField, obj });
+
+            DateTime now = DateTime.Now;
+
+            DataColumn[] columns = new[] {
+                new DataColumn(idField, new string[] { "id-1" }),
+                new DataColumn(metadata, new int[] { 1 }),
+                new DataColumn(prop1, new string[] { "prop1-value" }, new int[] { 0,1 }),
+                new DataColumn(prop2, new DateTime?[] { now }, new int[] { 0, 1 }),
+            };
+
+            long totalRowRount = 1;
+            var sut = new DataColumnsToRowsConverter(schema, columns, totalRowRount);
+
+            // act
+            IReadOnlyCollection<Row> rows = sut.Convert();
+
+            // assert
+            Assert.Single(rows);
+
+            Row row = rows.ElementAt(0);
+
+            string actualId = row.Values[0] as string;
+            Assert.Equal("id-1", actualId);
+
+            dynamic actualObj = row.Values[1] as dynamic;
+            int actualMetadata = actualObj.Values[0];
+
+            Assert.Equal(1, actualMetadata);
+
+            dynamic actualArray = actualObj.Values[1] as dynamic;
+            Assert.Equal("prop1-value", actualArray[0].Values[0]);
+            Assert.Equal(now, actualArray[0].Values[1]);
+        }
+
+        [Fact]
+        public void Convert_should_process_deeply_nested_structs_with_nulls_deeply_nested() {
+            // arrange
+            // create a complex nested schema
+            /*
+             * { id, obj: { metadata, arrray: [ {prop1, prop2}, {prop1, prop2} ] } }
+             */
+            var prop1 = new DataField("prop1", typeof(string), isNullable: true);
+            var prop2 = new DataField("prop2", typeof(DateTime?), isNullable: true);
+            var array = new ListField("array", new StructField("item", new Field[] { prop1, prop2 }));
+            var metadata = new DataField("metadata", typeof(int), isNullable: false);
+            var obj = new StructField("obj", new Field[] { metadata, array });
+            var idField = new DataField("id", typeof(string), isNullable: true);
+
+            var schema = new ParquetSchema(new Field[] { idField, obj });
+
+            DateTime now = DateTime.Now;
+
+            DataColumn[] columns = new[] {
+                new DataColumn(idField, new string[] { "id-1" }),
+                new DataColumn(metadata, new int[] { 1 }),
+                new DataColumn(prop1, new string[] { null }, new int[] { 0,1 }),
+                new DataColumn(prop2, new DateTime?[] { now }, new int[] { 0, 1 }),
+            };
+
+            long totalRowRount = 1;
+            var sut = new DataColumnsToRowsConverter(schema, columns, totalRowRount);
+
+            // act
+            IReadOnlyCollection<Row> rows = sut.Convert();
+
+            // assert
+            Assert.Single(rows);
+
+            Row row = rows.ElementAt(0);
+
+            string actualId = row.Values[0] as string;
+            Assert.Equal("id-1", actualId);
+
+            dynamic actualObj = row.Values[1] as dynamic;
+            int actualMetadata = actualObj.Values[0];
+
+            Assert.Equal(1, actualMetadata);
+
+            dynamic actualArray = actualObj.Values[1] as dynamic;
+            Assert.Equal(1, actualArray.Length);
+            Assert.Equal(now, actualArray[0].Values[0]);
+        }
+    }
+}

--- a/src/Parquet/Parquet.csproj
+++ b/src/Parquet/Parquet.csproj
@@ -59,11 +59,11 @@
     <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
         <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
         <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
-        <PackageReference Include="System.Text.Json" Version="8.0.3" />
+        <PackageReference Include="System.Text.Json" Version="8.0.4" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
-        <PackageReference Include="System.Text.Json" Version="8.0.3" />
+        <PackageReference Include="System.Text.Json" Version="8.0.4" />
     </ItemGroup>
 
 

--- a/src/Parquet/Rows/DataColumnsToRowsConverter.cs
+++ b/src/Parquet/Rows/DataColumnsToRowsConverter.cs
@@ -55,22 +55,6 @@ namespace Parquet.Rows {
             return rows;
         }
 
-        //private bool TryBuildNextRow(IReadOnlyCollection<Field> fields, Dictionary<FieldPath, LazyColumnEnumerator> pathToColumn,
-        //    out Row? row) {
-        //    var rowList = new List<object>();
-        //    foreach(Field f in fields) {
-        //        if(!TryBuildNextCell(f, pathToColumn, out object? cell)) {
-        //            row = null;
-        //            return false;
-        //        }
-
-        //        rowList.Add(cell!);
-        //    }
-
-        //    row = new Row(fields, rowList);
-        //    return true;
-        //}
-
         private bool TryBuildNextRow(IReadOnlyCollection<Field> fields, Dictionary<FieldPath, LazyColumnEnumerator> pathToColumn,
             out Row? row) {
             var rowList = new List<object>();

--- a/src/Parquet/Rows/DataColumnsToRowsConverter.cs
+++ b/src/Parquet/Rows/DataColumnsToRowsConverter.cs
@@ -55,20 +55,39 @@ namespace Parquet.Rows {
             return rows;
         }
 
+        //private bool TryBuildNextRow(IReadOnlyCollection<Field> fields, Dictionary<FieldPath, LazyColumnEnumerator> pathToColumn,
+        //    out Row? row) {
+        //    var rowList = new List<object>();
+        //    foreach(Field f in fields) {
+        //        if(!TryBuildNextCell(f, pathToColumn, out object? cell)) {
+        //            row = null;
+        //            return false;
+        //        }
+
+        //        rowList.Add(cell!);
+        //    }
+
+        //    row = new Row(fields, rowList);
+        //    return true;
+        //}
+
         private bool TryBuildNextRow(IReadOnlyCollection<Field> fields, Dictionary<FieldPath, LazyColumnEnumerator> pathToColumn,
             out Row? row) {
             var rowList = new List<object>();
+            bool anyCellBuilt = false;
+
             foreach(Field f in fields) {
                 if(!TryBuildNextCell(f, pathToColumn, out object? cell)) {
                     row = null;
-                    return false;
+                    continue;
+                } else {
+                    anyCellBuilt = true;
                 }
-
                 rowList.Add(cell!);
             }
 
-            row = new Row(fields, rowList);
-            return true;
+            row = anyCellBuilt ? new Row(fields, rowList) : null;
+            return anyCellBuilt;
         }
 
         private bool TryBuildNextCell(Field f, Dictionary<FieldPath, LazyColumnEnumerator> pathToColumn,


### PR DESCRIPTION
Data if one or more of the objects in the list has a null property value even if the type is properly nullable.
This results in missing visit Procedure data and likely other issues, but that is what alerted us to the issue.
Test and library verification done through unit tests. Without making any changes to their core library code, I have two test. One passing in the happy scenario with no nulls. And one failing which simulates our deeply nested null value scenario.